### PR TITLE
Fix inconsistencies in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -45,16 +45,16 @@ bookmark is a **desktop app for tracking reading progress and book loans, optimi
 **:information_source: Notes about the command format:**<br>
 
 * Words in `UPPER_CASE` are the parameters to be supplied by the user.<br>
-  e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
+  e.g. in `add n/BOOK_TITLE`, `BOOK_TITLE` is a parameter which can be used as `add n/Harry Potter`.
 
 * Items in square brackets are optional.<br>
-  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
+  e.g `n/BOOK_TITLE [b/PAGE_NUMBER]` can be used as `n/Harry Potter b/64` or as `n/Harry Potter`.
 
 * Items with `…`​ after them can be used multiple times including zero times.<br>
   e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
 * Parameters can be in any order.<br>
-  e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
+  e.g. if the command specifies `n/BOOK_TITLE tp/TOTAL_PAGES`, `tp/TOTAL_PAGES n/BOOK_TITLE` is also acceptable.
 
 </div>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -87,13 +87,13 @@ Examples:
     * **bookmark:** Page 138
     * **read**: 138/200 (69%)
 
-### Listing all persons : `list`
+### Listing all books : `list`
 
 Shows a list of all books in the Storage Library.
 
 Format: `list`
 
-### Locating persons by name: `find` [coming soon]
+### Locating books by name: `find` [coming soon]
 
 Find books whose names contain any of the given keywords.
 
@@ -110,13 +110,12 @@ Format: `delete INDEX`
 
 Examples:
 * `list` followed by `delete 2` deletes the 2nd book in the book list.
-* `find MyBook` followed by `delete 1` deletes the 1st book in the results of the `find` command.
 
-### Editing a person : `edit`
+### Editing a book : `edit`
 
 Edits an existing book in the list.
 
-Format: `edit INDEX b/PAGE_NUMBER​`
+Format: `edit INDEX [n/BOOK_TITLE] [tp/TOTAL_PAGES] [b/PAGE_NUMBER]`
 
 * Edits the book at the specified `INDEX`. The index refers to the index number shown in the displayed book list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -124,11 +123,10 @@ Format: `edit INDEX b/PAGE_NUMBER​`
 
 Examples:
 *  `edit 1 b/101` Edits the bookmark of the 1st book to be `101`.
-* `find MyBook` followed by `edit 1 b/101` edits the 1st book in the results of the `find` command and sets the bookmark page to `101`.
 
-### Clearing all entries : `clear` [coming soon]
+### Clearing all books : `clear` [coming soon]
 
-Clears all entries from the Storage Library.
+Clears all books from the Storage Library.
 
 Format: `clear`
 
@@ -155,8 +153,9 @@ bookmark data will be saved in the hard disk automatically after any command tha
 
 Action | Format, Examples
 --------|------------------
-**Add** | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
+**Add** | `add n/BOOK_TITLE tp/TOTAL_PAGES b/PAGE_NUMBER` <br> e.g., `add n/Harry Potter and the Chamber of Secrets tp/1500 b/25`
 **Clear** | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **List** | `list`
+**View** | `view INDEX` <br> e.g., `view 3`
 **Edit** | `edit INDEX b/PAGE_NUMBER`


### PR DESCRIPTION
Closes #69 
The following changes were made:
* Remove left-over usages of "address" and "person" from the AB3 User Guide
* Make the usages of notation consistent throughout the User Guide
    * Notation used in the User Guide to describe the command syntax is now consistent with what was defined originally by the AB3 User Guide
* Update the Command summary table