### PR TITLE
Fix leading zeroes problem and refactor ListCommand

### DIFF
--- a/src/main/java/seedu/bookmark/commons/core/LogsCenter.java
+++ b/src/main/java/seedu/bookmark/commons/core/LogsCenter.java
@@ -18,7 +18,7 @@ import java.util.logging.SimpleFormatter;
 public class LogsCenter {
     private static final int MAX_FILE_COUNT = 5;
     private static final int MAX_FILE_SIZE_IN_BYTES = (int) (Math.pow(2, 20) * 5); // 5MB
-    private static final String LOG_FILE = "addressbook.log";
+    private static final String LOG_FILE = "bookmark.log";
     private static Level currentLogLevel = Level.INFO;
     private static final Logger logger = LogsCenter.getLogger(LogsCenter.class);
     private static FileHandler fileHandler;

--- a/src/main/java/seedu/bookmark/commons/util/StringUtil.java
+++ b/src/main/java/seedu/bookmark/commons/util/StringUtil.java
@@ -65,4 +65,16 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Converts {@code s} representing an unsigned integer into a String representing the same integer but with
+     * any leading "0"s removed.
+     *
+     * @param s String representing a non-zero unsigned integer
+     */
+    public static String trimLeadingZeroes(String s) {
+        requireNonNull(s);
+        int value = Integer.parseInt(s);
+        return String.valueOf(value);
+    }
 }

--- a/src/main/java/seedu/bookmark/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/bookmark/logic/commands/ListCommand.java
@@ -6,13 +6,13 @@ import static seedu.bookmark.model.Model.PREDICATE_SHOW_ALL_BOOKS;
 import seedu.bookmark.model.Model;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists all books in the library to the user.
  */
 public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all books";
 
 
     @Override

--- a/src/main/java/seedu/bookmark/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/bookmark/logic/parser/ParserUtil.java
@@ -102,6 +102,7 @@ public class ParserUtil {
         if (!TotalPages.isValidTotalPages(trimmedTotalPages)) {
             throw new ParseException(TotalPages.MESSAGE_CONSTRAINTS);
         }
+        trimmedTotalPages = StringUtil.trimLeadingZeroes(trimmedTotalPages);
         return new TotalPages(trimmedTotalPages);
     }
 
@@ -117,6 +118,7 @@ public class ParserUtil {
             if (!Bookmark.isValidBookmark(trimmedBookmark)) {
                 throw new ParseException(Bookmark.MESSAGE_CONSTRAINTS);
             }
+            trimmedBookmark = StringUtil.trimLeadingZeroes(trimmedBookmark);
             return new Bookmark(trimmedBookmark);
         }
     }


### PR DESCRIPTION
Let's merge #85 first before we merge this PR

Closes #86 
Add a `trimLeadingZeroes` method in `commons.util.StringUtil` utility class that removes leading zeroes from Strings representing an unsigned integer.

The method is used in the `parseTotalPages` and `parseBookmark` methods in `logic.parser.ParserUtil` to trim off any leading zeroes from the user input TotalPages and Bookmark page

Closes #42 
Rename usages of 'person' to 'book' in ListCommand