### PR TITLE
Ui bug fixes

### DIFF
--- a/src/main/java/seedu/bookmark/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/bookmark/logic/commands/EditCommand.java
@@ -86,7 +86,6 @@ public class EditCommand extends Command {
             throw new CommandException(Bookmark.MESSAGE_CONSTRAINTS);
         }
         model.setBook(bookToEdit, editedBook);
-        model.updateFilteredBookList(PREDICATE_SHOW_ALL_BOOKS);
         model.sortByDefaultComparator();
         return new CommandResult(String.format(MESSAGE_EDIT_BOOK_SUCCESS, editedBook),
                 false, false, ViewType.MOST_RECENTLY_USED);

--- a/src/main/java/seedu/bookmark/logic/commands/GoalCommand.java
+++ b/src/main/java/seedu/bookmark/logic/commands/GoalCommand.java
@@ -67,7 +67,8 @@ public class GoalCommand extends Command {
 
         model.setBook(bookWithoutGoal, bookWithGoal);
 
-        return new CommandResult(String.format(MESSAGE_ADD_GOAL_SUCCESS, bookWithGoal.getName(), goal.toString()));
+        return new CommandResult(String.format(MESSAGE_ADD_GOAL_SUCCESS, bookWithGoal.getName(), goal.toString()),
+                false, false, CommandResult.ViewType.MOST_RECENTLY_USED);
     }
 
     @Override

--- a/src/main/java/seedu/bookmark/logic/commands/GoalDelCommand.java
+++ b/src/main/java/seedu/bookmark/logic/commands/GoalDelCommand.java
@@ -44,7 +44,8 @@ public class GoalDelCommand extends Command {
 
         model.setBook(bookWithGoal, bookWithoutGoal);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, bookWithGoal.getName()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, bookWithGoal.getName()), false, false,
+                CommandResult.ViewType.MOST_RECENTLY_USED);
     }
 
     @Override

--- a/src/main/java/seedu/bookmark/ui/MainWindow.java
+++ b/src/main/java/seedu/bookmark/ui/MainWindow.java
@@ -230,6 +230,10 @@ public class MainWindow extends UiPart<Stage> {
                 }
                 break;
             case MOST_RECENTLY_USED:
+                if (logic.getFilteredBookList().size() > 1) {
+                    // cannot keep using detailed view if there are > 1 books to display
+                    resetView();
+                }
                 break;
             default:
                 break;

--- a/src/test/java/seedu/bookmark/logic/commands/GoalCommandTest.java
+++ b/src/test/java/seedu/bookmark/logic/commands/GoalCommandTest.java
@@ -35,7 +35,9 @@ public class GoalCommandTest {
                 bookToSetGoal.getName(), validGoal.toString());
         expectedModel.setBook(bookToSetGoal, bookWithGoal);
 
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        CommandResult expectedResult = new CommandResult(expectedMessage, false, false,
+                CommandResult.ViewType.MOST_RECENTLY_USED);
+        assertCommandSuccess(command, model, expectedResult, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/bookmark/logic/commands/GoalDelCommandTest.java
+++ b/src/test/java/seedu/bookmark/logic/commands/GoalDelCommandTest.java
@@ -34,7 +34,8 @@ public class GoalDelCommandTest {
         // Expected model stays default
 
         String expectedMsg = String.format(GoalDelCommand.MESSAGE_SUCCESS, bookToChange.getName());
-        CommandResult expectedResult = new CommandResult(expectedMsg);
+        CommandResult expectedResult = new CommandResult(expectedMsg, false, false,
+                CommandResult.ViewType.MOST_RECENTLY_USED);
 
         assertCommandSuccess(cmd, model, expectedResult, expectedModel);
     }


### PR DESCRIPTION
Closes #131 
- Make GoalCommand and GoalDelCommand return a CommandResult that uses ViewType.MOST_RECENTLY_USED

Closes #134 
- Add a check in `MainWindow` to ensure detailed view is not used if there's more than 1 book to display 